### PR TITLE
修正 cvtcolor demo 編譯缺少 Dynamically loaded (DL) libraries 的問題

### DIFF
--- a/samples/cvtcolor_demo/src/CMakeLists.txt
+++ b/samples/cvtcolor_demo/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(rga_cvtcolor_demo
 target_link_libraries(rga_cvtcolor_demo
     utils_obj
     ${RGA_LIB}
+    dl
 )
 install(TARGETS rga_cvtcolor_demo DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -15,6 +16,7 @@ add_executable(rga_cvtcolor_csc_demo
 target_link_libraries(rga_cvtcolor_csc_demo
     utils_obj
     ${RGA_LIB}
+    dl
 )
 install(TARGETS rga_cvtcolor_csc_demo DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -25,5 +27,6 @@ add_executable(rga_cvtcolor_gray256_demo
 target_link_libraries(rga_cvtcolor_gray256_demo
     utils_obj
     ${RGA_LIB}
+    dl
 )
 install(TARGETS rga_cvtcolor_gray256_demo DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/samples/cvtcolor_demo/src/rga_cvtcolor_gray256_demo.cpp
+++ b/samples/cvtcolor_demo/src/rga_cvtcolor_gray256_demo.cpp
@@ -29,7 +29,6 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/mman.h>
-#include <>
 #include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>


### PR DESCRIPTION
- 修正 cvtcolor demo 編譯缺少 Dynamically loaded (DL) libraries 的問題
![image](https://github.com/airockchip/librga/assets/90902880/f6143884-9fc1-4680-84c5-e6b12a8e006b)
