### PR TITLE
docs: clarify DMA32 heap requirement

### DIFF
--- a/docs/Rockchip_FAQ_RGA_CN.md
+++ b/docs/Rockchip_FAQ_RGA_CN.md
@@ -938,16 +938,6 @@ rga_policy: start policy on core = 4
 
  **<librga_souce_path>/samples/allocator_demo/src/rga_allocator_graphicbuffer_demo.cpp**
 
-   `rga_allocator_dma32_demo.cpp` 假设内核已经提供 DMA32 heap。运行示例前可先检查：
-
-   ```shell
-   ls -l /dev/dma_heap
-   ```
-
-   如果不存在 `system-dma32` 或 `system-uncached-dma32` 节点，需要在对应平台的
-   kernel/BSP 中启用或移植 DMA32 heap 支持。该示例不会创建 heap，也不要静默
-   回退到普通 system heap，因为普通 heap 不能保证分配到4G以内的物理内存。
-
 
 
 **Q1.10**：为什么调用RGA API时发现API返回耗时远高于驱动打印硬件耗时？
@@ -1457,6 +1447,16 @@ Failed to call RockChipRga interface, please use 'dmesg' command to view driver 
     **<librga_souce_path>/samples/allocator_demo/src/rga_allocator_dma32_demo.cpp**
 
     **<librga_souce_path>/samples/allocator_demo/src/rga_allocator_graphicbuffer_demo.cpp**
+
+   `rga_allocator_dma32_demo.cpp` 假设内核已经提供 DMA32 heap。运行示例前可先检查：
+
+   ```shell
+   ls -l /dev/dma_heap
+   ```
+
+   如果不存在 `system-dma32` 或 `system-uncached-dma32` 节点，需要在对应平台的
+   kernel/BSP 中启用或移植 DMA32 heap 支持。该示例不会创建 heap，也不要静默
+   回退到普通 system heap，因为普通 heap 不能保证分配到4G以内的物理内存。
 
    如果使用的其他分配器，例如mpp_buffer、v4l2_buffer、drm_buffer等，请查询对应分配器是否支持限制分配4G以内内存空间内存，并按照对应方式申请复合RGA硬件要求的内存。
 

--- a/docs/Rockchip_FAQ_RGA_CN.md
+++ b/docs/Rockchip_FAQ_RGA_CN.md
@@ -938,6 +938,16 @@ rga_policy: start policy on core = 4
 
  **<librga_souce_path>/samples/allocator_demo/src/rga_allocator_graphicbuffer_demo.cpp**
 
+   `rga_allocator_dma32_demo.cpp` 假设内核已经提供 DMA32 heap。运行示例前可先检查：
+
+   ```shell
+   ls -l /dev/dma_heap
+   ```
+
+   如果不存在 `system-dma32` 或 `system-uncached-dma32` 节点，需要在对应平台的
+   kernel/BSP 中启用或移植 DMA32 heap 支持。该示例不会创建 heap，也不要静默
+   回退到普通 system heap，因为普通 heap 不能保证分配到4G以内的物理内存。
+
 
 
 **Q1.10**：为什么调用RGA API时发现API返回耗时远高于驱动打印硬件耗时？

--- a/docs/Rockchip_FAQ_RGA_EN.md
+++ b/docs/Rockchip_FAQ_RGA_EN.md
@@ -1437,6 +1437,18 @@ When this error occurs, there are usually the following scenarios and correspond
 
      **<librga_souce_path>/samples/allocator_demo/src/rga_allocator_graphicbuffer_demo.cpp**
 
+    `rga_allocator_dma32_demo.cpp` assumes that the kernel already provides a
+    DMA32 heap. Check the available heaps before running the sample:
+
+    ```shell
+    ls -l /dev/dma_heap
+    ```
+
+    If neither `system-dma32` nor `system-uncached-dma32` is present, enable or
+    port DMA32 heap support in the platform kernel/BSP. The sample does not
+    create the heap. Do not silently fall back to the regular system heap,
+    because it cannot guarantee a physical address below 4 GB.
+
     If you use other allocators, such as mpp_buffer, v4l2_buffer, drm_buffer, etc., please check whether the corresponding allocator supports the limited allocation of memory space within 4G, and apply for the memory required by the composite RGA hardware according to the corresponding method.
 
 3. On chip platforms that only carry one RGA (such as RK3399, RK3568, and Rk3566 that only carry RGA2):


### PR DESCRIPTION
References #143.

The DMA32 allocator sample assumes that the platform kernel already
provides a DMA32 heap. Clarify in both FAQ translations how to inspect
the available heap nodes, where support must be enabled when they are
missing, and why falling back to the regular system heap is unsafe for
RGA2's under-4-GB addressing requirement.

Checks:
- `git diff --check`
- verified both referenced allocator samples exist

This is a documentation-only change. No RK3588/RGA board validation was
performed.